### PR TITLE
Fix macosx.install.sh for 10.8

### DIFF
--- a/macosx.install.sh
+++ b/macosx.install.sh
@@ -5,7 +5,7 @@ AVBIN_LIBRARY=libavbin.@AVBIN_VERSION@.dylib
 
 if [ ! -d "$PREFIX" ]
 then
-  mkdir $PREFIX
+  mkdir -p $PREFIX
 fi
 
 /bin/ln -sf /usr/local/lib/$AVBIN_LIBRARY $PREFIX/libavbin.dylib


### PR DESCRIPTION
Fix instance of a clean install of 10.8 missing /usr/local/lib by
checking for its existence and creating if needed
