### PR TITLE
Improving stability and accuracy of seeking

### DIFF
--- a/src/avbin.c
+++ b/src/avbin.c
@@ -223,8 +223,8 @@ AVbinResult avbin_seek_file(AVbinFile *file, AVbinTimestamp timestamp)
 
     if (!timestamp)
     {
-        if (av_seek_frame(file->context, -1, 0,
-                          AVSEEK_FLAG_ANY | AVSEEK_FLAG_BYTE) < 0)
+        flags = AVSEEK_FLAG_ANY | AVSEEK_FLAG_BYTE;
+        if (av_seek_frame(file->context, -1, 0, flags) < 0)
             return AVBIN_RESULT_ERROR;
     }
     else


### PR DESCRIPTION
If avbin_seek_file is used before avbin_read, avbin seg faults in avcodec_flush_buffers.

Also, backwards flag is set which improves accuracy of seeking.
