### PR TITLE
Make deprecated function work in visual studio 2010

### DIFF
--- a/include/avbin.h
+++ b/include/avbin.h
@@ -506,8 +506,12 @@ AVbinInfo *avbin_get_info();
  *             This always returns 0 now that we use Libav from Git.  This
  *             function will be removed in AVbin 12.
  */
+#ifndef _MSC_VER
 int32_t avbin_get_ffmpeg_revision() __attribute__((deprecated));
-
+#else
+int32_t avbin_get_ffmpeg_revision();
+#pragma deprecated(avbin_get_ffmpeg_revision)
+#endif
 
 /**
  * Get the minimum audio buffer size, in bytes.


### PR DESCRIPTION
Visual studio has a different style in marking a function as deprecated. I modified the header to use both the gnu style and visual studio style deprecated syntax.
